### PR TITLE
Feat: 챗봇 모든 대화 히스토리 조회 기능 구현

### DIFF
--- a/src/main/java/com/finz/controller/CoachController.java
+++ b/src/main/java/com/finz/controller/CoachController.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import com.finz.dto.coach.CoachMessageDto;
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -40,5 +42,15 @@ public class CoachController {
         
         CoachResponseDto response = coachService.generateResponse(DEFAULT_USER_ID, request);
         return ResponseEntity.ok(response);
+    }
+
+    // 그간의 대화 내역 조회
+    @GetMapping("/history")
+    @Operation(summary = "대화 내역 조회", description = "AI 코치와의 전체 대화 내역을 조회합니다.")
+    public ResponseEntity<List<CoachMessageDto>> getChatHistory() {
+        log.info("대화 내역 조회 요청 - userId: {}", DEFAULT_USER_ID);
+
+        List<CoachMessageDto> history = coachService.getChatHistory(DEFAULT_USER_ID);
+        return ResponseEntity.ok(history);
     }
 }

--- a/src/main/java/com/finz/domain/coach/CoachMessageRepository.java
+++ b/src/main/java/com/finz/domain/coach/CoachMessageRepository.java
@@ -11,4 +11,6 @@ public interface CoachMessageRepository extends JpaRepository<CoachMessage, Long
     // 사용자별 최근 대화 조회 (최신순)
     List<CoachMessage> findTop20ByUserIdOrderByCreatedAtDesc(Long userId);
 
+    // 채팅방 입장 시 '전체' 대화 내역을 불러오기 위한 메서드 (시간 오름차순)
+    List<CoachMessage> findByUserIdOrderByCreatedAtAsc(Long userId);
 }

--- a/src/main/java/com/finz/dto/coach/CoachMessageDto.java
+++ b/src/main/java/com/finz/dto/coach/CoachMessageDto.java
@@ -1,0 +1,30 @@
+package com.finz.dto.coach;
+
+import com.finz.domain.coach.CoachMessage;
+import com.finz.domain.coach.MessageSender;
+import com.finz.domain.coach.MessageType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+// 과거 채팅 내역 조회용 DTO
+@Getter
+@Builder
+public class CoachMessageDto {
+    private Long messageId;
+    private MessageSender sender;
+    private MessageType messageType;
+    private String content;
+    private LocalDateTime createdAt;
+
+    public static CoachMessageDto fromEntity(CoachMessage entity) {
+        return CoachMessageDto.builder()
+                .messageId(entity.getMessageId())
+                .sender(entity.getSender())
+                .messageType(entity.getMessageType())
+                .content(entity.getContent())
+                .createdAt(entity.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/finz/service/CoachService.java
+++ b/src/main/java/com/finz/service/CoachService.java
@@ -33,7 +33,20 @@ public class CoachService {
     private final GoalRepository goalRepository;
     private final ExpenseRepository expenseRepository;
     private final GeminiApiClient geminiClient;
-    
+
+    @Transactional(readOnly = true) // 데이터 변경이 없는 조회 작업
+    public List<CoachMessageDto> getChatHistory(Long userId) {
+        log.info("대화 내역 조회 - userId: {}", userId);
+
+        // 1. Repository를 통해 엔티티 조회 (시간 오름차순)
+        List<CoachMessage> messages = messageRepository.findByUserIdOrderByCreatedAtAsc(userId);
+
+        // 2. 엔티티 리스트를 DTO 리스트로 변환
+        return messages.stream()
+                .map(CoachMessageDto::fromEntity) // DTO의 팩토리 메서드 사용
+                .collect(Collectors.toList());
+    }
+
     // 빠른 제안: 목표 설정 대화 시작
     @Transactional
     public CoachResponseDto startGoalSettingConversation(Long userId) {


### PR DESCRIPTION
✅ PR Type (하나 이상의 PR 타입 선택)
- [x]  기능 추가
- [ ]  기능 수정
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트
<br>

## 📌 Issues
- close #18 
<br>

## 🌲 Branch
- dev-feat-chat-message -> main
<br>

## 📝 Work Description
- 채팅방 내부에 보여주기 위한 전체 대화 내역 조회를 구현했습니다.

### 변경 사항
- `CoachMessageDto` 작성: 대화 내역 목록 조회를 위한 DTO 작성

### 수정 사항
- `CoachMessageRepository` 변경: 전채 대화 내역 조회 메서드 추가
- `CoachService` 변경: getChatHistory 메서드 추가
- `CoachController` 변경: 대화내역 요청 엔드포인트 추가 
<br>

## ✨ Result
<img width="1400" height="701" alt="image" src="https://github.com/user-attachments/assets/6b9ea39a-18d1-4a96-836e-bd5a5fcb1350" />